### PR TITLE
feat: add recursive deps

### DIFF
--- a/exercises/npm-registry/src/package.ts
+++ b/exercises/npm-registry/src/package.ts
@@ -1,22 +1,53 @@
-import { RequestHandler } from 'express';
-import got from 'got';
-import { NPMPackage } from './types';
+import { RequestHandler } from "express";
+import got from "got";
+import { minSatisfying } from "semver";
+import { NPMPackage } from "./types";
 
 /**
  * Attempts to retrieve package data from the npm registry and return it
  */
 export const getPackage: RequestHandler = async function (req, res, next) {
   const { name, version } = req.params;
-
+  const dependencyTree = {};
   try {
     const npmPackage: NPMPackage = await got(
-      `https://registry.npmjs.org/${name}`,
+      `https://registry.npmjs.org/${name}`
     ).json();
 
     const dependencies = npmPackage.versions[version].dependencies;
 
-    return res.status(200).json({ name, version, dependencies });
+    for (const [dep, version] of Object.entries(dependencies as Object)) {
+      const subDep = await getDependencies(dep, version);
+      dependencyTree[dep] = { version, dependecies: subDep };
+    }
+
+    return res
+      .status(200)
+      .json({ name, version, dependencies: dependencyTree });
   } catch (error) {
     return next(error);
   }
 };
+
+async function getDependencies(name, version) {
+  return got(`https://registry.npmjs.org/${name}`)
+    .json()
+    .then((npmPackage: any) => {
+      let v = minSatisfying(Object.keys(npmPackage.versions), version);
+
+      if (v) {
+        const dependencyTree = {};
+        const newDeps = npmPackage.versions[v].dependencies;
+        for (const [dep, version] of Object.entries(
+          newDeps || ({} as Object)
+        )) {
+          const subDep = getDependencies(dep, version);
+          dependencyTree[dep] = { version, dependecies: subDep };
+        }
+
+        return dependencyTree;
+      } else {
+        return {};
+      }
+    });
+}


### PR DESCRIPTION
Fixes [#123](https://github.com/sharonsit/jobs/tree/579579ec57713e10ff11e621b5afa52f9b20d10f/exercises/npm-registry#task)

This pull request implements nested dependencies on the /package endpoint. When making a request for a specific package and version the full tree of dependencies will be returned as JSON.

We will always return the latest matching version of a package supported to mimic the behavior of a fresh npm install.

It can be tested by making a request for a package with sub-dependencies e.g. react@16.13.0
```
curl -s http://localhost:3000/package/react/16.13.0 | jq .
```